### PR TITLE
Removed *.stl mime-type description from cura.sharedmimeinfo

### DIFF
--- a/com.ultimaker.cura.yml
+++ b/com.ultimaker.cura.yml
@@ -268,6 +268,8 @@ modules:
         tag: 4.13.1
       - type: patch
         path: patch/cura-fix-appdata.patch
+      - type: patch
+        path: patch/cura-mimeinfo.patch
 
 
   - name: cura-binary-data

--- a/patch/cura-mimeinfo.patch
+++ b/patch/cura-mimeinfo.patch
@@ -1,0 +1,17 @@
+diff --git a/cura.sharedmimeinfo b/cura.sharedmimeinfo
+index ed9099d42..d63d757e8 100644
+--- a/cura.sharedmimeinfo
++++ b/cura.sharedmimeinfo
+@@ -6,12 +6,6 @@
+         <glob-deleteall/>
+         <glob pattern="*.3mf"/>
+     </mime-type>
+-    <mime-type type="model/stl">
+-        <comment>Computer-aided design and manufacturing format</comment>
+-        <icon name="unknown"/>
+-        <glob-deleteall/>
+-        <glob pattern="*.stl"/>
+-    </mime-type>
+     <mime-type type="application/prs.wavefront-obj">
+         <sub-class-of type="text/plain"/>
+         <comment>Wavefront 3D Object file</comment>

--- a/python-modules/base-requirements.json
+++ b/python-modules/base-requirements.json
@@ -4,20 +4,6 @@
     "build-commands": [],
     "modules": [
         {
-            "name": "python3-wheel",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=/app \"wheel==0.37.0\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/04/80/cad93b40262f5d09f6de82adbee452fd43cdff60830b56a74c5930f7e277/wheel-0.37.0-py2.py3-none-any.whl",
-                    "sha256": "21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd"
-                }
-            ]
-        },
-        {
             "name": "python3-pybind11",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
Addresses #2 
The shared-mime-info package already contains a translated type description for *.stl, this can be used instead.