### PR TITLE
Add Unset QT_STYLE_OVERRIDE to the start script

### DIFF
--- a/com.ultimaker.cura.yml
+++ b/com.ultimaker.cura.yml
@@ -49,4 +49,5 @@ modules:
     - type: script
       dest-filename: start-cura-flatpak.sh
       commands:
+        - unset QT_STYLE_OVERRIDE
         - /app/AppRun "$@"


### PR DESCRIPTION
If this variable is set it causes start problems on Zorin OS

https://github.com/Ultimaker/Cura/issues/12343